### PR TITLE
fixing monthly_uploads_left calculattion

### DIFF
--- a/src/app/(authenticated)/upload-contract/page.tsx
+++ b/src/app/(authenticated)/upload-contract/page.tsx
@@ -107,10 +107,10 @@ export default function UploadContractPage() {
 
   // Compute remaining monthly uploads
   const monthlyUploadsLeft = useMemo(() => {
-    if (!productSubscription) {
-      return 0
-    }
     const freeUsage = isFreeUsageUsed ? 0 : 1
+    if (!productSubscription) {
+      return freeUsage
+    }
     return parseInt(productSubscription.product.metadata.monthly_uploads, 10) + freeUsage - contractsList.length
   }, [productSubscription, contractsList, isFreeUsageUsed])
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix incorrect calculation of remaining monthly uploads when no product subscription exists.